### PR TITLE
refactor(broker): AsyncProducer function to apply options directly within the returned function

### DIFF
--- a/v5/broker/kafka/options.go
+++ b/v5/broker/kafka/options.go
@@ -28,15 +28,14 @@ type asyncProduceErrorKey struct{}
 type asyncProduceSuccessKey struct{}
 
 func AsyncProducer(errors chan<- *sarama.ProducerError, successes chan<- *sarama.ProducerMessage) broker.Option {
-	// set default opt
-	var opt = func(options *broker.Options) {}
-	if successes != nil {
-		opt = setBrokerOption(asyncProduceSuccessKey{}, successes)
+	return func(options *broker.Options) {
+		if errors != nil {
+			setBrokerOption(asyncProduceErrorKey{}, errors)(options)
+		}
+		if successes != nil {
+			setBrokerOption(asyncProduceSuccessKey{}, successes)(options)
+		}
 	}
-	if errors != nil {
-		opt = setBrokerOption(asyncProduceErrorKey{}, errors)
-	}
-	return opt
 }
 
 type subscribeContextKey struct{}


### PR DESCRIPTION
## Description

This PR addresses an issue where the AsyncProducer function could not be used as demonstrated in the README.md example. The original implementation of AsyncProducer returned a single option function that could only apply one of the errors or successes channels, leading to incorrect behavior when both channels were provided.

## Changes

- Refactored the AsyncProducer function to apply both the errors and successes channels directly within the returned function, ensuring that both options are correctly set on the broker.Options.
- This update ensures that the AsyncProducer function behaves as expected when used in accordance with the example provided in the README.md.

This fix allows users to properly capture both producer errors and successes when using the AsyncProducer function, improving the reliability and correctness of the Kafka broker setup.